### PR TITLE
Fix map embed url

### DIFF
--- a/src/components/contact/ContactMap.tsx
+++ b/src/components/contact/ContactMap.tsx
@@ -4,7 +4,7 @@ const ContactMap: React.FC = () => {
   return (
     <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg overflow-hidden">
       <iframe
-        src="https://www.google.com/maps/place/La+Belle+Cutanee/@-23.590952,-46.6310473,17z/data=!3m1!4b1!4m6!3m5!1s0x94ce5b0009055d5b:0x7c7b39bdf68dff18!8m2!3d-23.5909569!4d-46.6284724!16s%2Fg%2F11y2n5smhw?entry=ttu&g_ep=EgoyMDI1MDcyMy4wIKXMDSoASAFQAw%3D%3D"
+        src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3656.9!2d-46.6310473!3d-23.590952!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x94ce5b0009055d5b:0x7c7b39bdf68dff18!2sLa%20Belle%20Cutan%C3%A9e!5e0!3m2!1sen!2sbr!4v1710000000000!5m2!1sen!2sbr"
         width="100%"
         height="450"
         style={{ border: 0 }}


### PR DESCRIPTION
## Summary
- update the map embed to use Google Maps embed share URL

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_688a2728dc648329a61417c3475e7254